### PR TITLE
Fix summary R2 links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.3.4 - Bug Fix: summary photo links
+- Ensure `shared/summary.js` always appends direct R2 image URLs to the
+  consultation summary if the model omits them.
+
 ## v1.3.3 - Bug Fix: progress status never updated
 - Update workers/whatsapp.js to set `progress_status` to `photo-received` or `midway`
   based on incoming messages so scheduler emails and nudges trigger correctly.

--- a/shared/summary.js
+++ b/shared/summary.js
@@ -41,5 +41,11 @@ export async function generateOrFetchSummary({ env, session, phone, baseUrl }) {
     })),
   ];
   const summary = await chatCompletion(messages, env.OPENAI_API_KEY);
-  return summary;
+  // Ensure photo URLs are included even if the model omits them
+  let finalSummary = summary;
+  if (photoUrls.length > 0 && !photoUrls.every(url => summary.includes(url))) {
+    const photoSection = `Photos Provided: ${photoUrls.join(' | ')}`;
+    finalSummary = `${summary}\n${photoSection}`;
+  }
+  return finalSummary;
 }


### PR DESCRIPTION
## Notes
- ensure summary generator always includes image URLs
- document patch in changelog

## Testing
- `node --input-type=module - <<'EOF'
import { generateOrFetchSummary } from './shared/summary.js';
console.log(typeof generateOrFetchSummary);
EOF`
