### PR TITLE
Remove outdated vibe folder references

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository uses a multi-worker setup to separate concerns across different 
 - **Upload-hook worker** (`workers/upload-hook.js`): GitHub webhook endpoint to trigger automatic document sync.
 - **Shared utilities** (`shared/`): common modules for GPT, embeddings, chunking, and prompt building.
 
-For detailed prompt configuration, see [VIBE_PROMPT.md](vibe/plans/success/VIBE_PROMPT.md).
+For detailed prompt configuration, see [VIBE_PROMPT.md](docs/issues/05-closed/VIBE_PROMPT.md).
 
 ## Features
 

--- a/docs/issues/05-closed/v1.1.6-deployment-debug.md
+++ b/docs/issues/05-closed/v1.1.6-deployment-debug.md
@@ -42,7 +42,7 @@ workers/
 v1.1.6
 ```
 
-7. Move this file from `vibe_plans/pending/` to `vibe_plans/success/`.
+7. After verifying the fix, place this file in `docs/issues/05-closed/`.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix README prompt link to use docs path
- update old issue plan instructions referencing the vibe folder

## Testing
- `npm test` *(fails: could not find package.json)*