### PR TITLE
Implement R2 cleanup on conversation reset

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,6 +56,7 @@ This document describes the architecture of the AI-powered WhatsApp consultation
 - Retention: 24-hour TTL
 - Memory key: `chat_history:<phoneNumber>`
 - Supports resetting conversation when users send reset keywords ("reset", "clear", "start over", "new consultation")
+  - Uploaded R2 images are deleted during reset to avoid orphaned media
 - Stores session metadata alongside history (progress_status, last_active, summary_email_sent, nudge_sent, summary, r2Urls)
 
 ### 5. **Cloudflare R2 (Optional Image Hosting)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - Ensure `shared/summary.js` always appends direct R2 image URLs to the
   consultation summary if the model omits them.
 
+## v1.3.6 - Cleanup R2 images on reset
+- Deleting conversations now also removes any R2-hosted photos for that phone number
+- Added r2 cleanup helper and tests
+
 ## v1.3.3 - Bug Fix: progress status never updated
 - Update workers/whatsapp.js to set `progress_status` to `photo-received` or `midway`
   based on incoming messages so scheduler emails and nudges trigger correctly.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For detailed prompt configuration, see [VIBE_PROMPT.md](docs/issues/05-closed/VI
 
 - Accept incoming WhatsApp messages (text & images) from Twilio
 - Short-term memory with KV storage (`CHAT_HISTORY`)
-- Reset conversation via keywords ("reset", "clear", "start over", "new consultation")
+- Reset conversation via keywords ("reset", "clear", "start over", "new consultation") which also removes any uploaded photos from R2
 - System prompt & chat history injection for GPT-4o-mini
 - GPT-4o-mini vision support for understanding images
 - Generates TwiML responses for Twilio webhook

--- a/__tests__/r2.test.js
+++ b/__tests__/r2.test.js
@@ -1,0 +1,17 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { r2KeyFromUrl, deleteR2Objects } from '../shared/r2.js';
+
+describe('r2 helpers', () => {
+  it('extracts key from URL', () => {
+    const url = 'https://wa.example.com/images/a%2Fb.jpg';
+    assert.strictEqual(r2KeyFromUrl(url), 'a/b.jpg');
+  });
+
+  it('deletes keys from bucket', async () => {
+    const deleted = [];
+    const env = { MEDIA_BUCKET: { delete: async key => { deleted.push(key); } } };
+    await deleteR2Objects(env, ['a.jpg', 'b.jpg']);
+    assert.deepStrictEqual(deleted, ['a.jpg', 'b.jpg']);
+  });
+});

--- a/docs/VIBE_CHECK.md
+++ b/docs/VIBE_CHECK.md
@@ -86,10 +86,10 @@ https://wa.me/16895292934?text=<encoded summary>
 
 | Input Message       | Expected Behavior                                  |
 |---------------------|----------------------------------------------------|
-| `reset`             | KV entry deleted, reset message returned           |
-| `clear`             | KV entry deleted, reset message returned           |
-| `start over`        | KV entry deleted, reset message returned           |
-| `new consultation`  | KV entry deleted, reset message returned           |
+| `reset`             | KV entry deleted, uploaded images removed from R2, reset message returned |
+| `clear`             | KV entry deleted, uploaded images removed from R2, reset message returned |
+| `start over`        | KV entry deleted, uploaded images removed from R2, reset message returned |
+| `new consultation`  | KV entry deleted, uploaded images removed from R2, reset message returned |
 | any other message   | Normal assistant flow continues                    |
 
 ---

--- a/shared/r2.js
+++ b/shared/r2.js
@@ -1,0 +1,17 @@
+export function r2KeyFromUrl(url) {
+  try {
+    return decodeURIComponent(new URL(url).pathname.replace('/images/', ''));
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteR2Objects(env, keys = []) {
+  for (const key of keys) {
+    try {
+      await env.MEDIA_BUCKET.delete(key);
+    } catch (err) {
+      console.error('R2 delete error', key, err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- delete uploaded R2 images when resetting a chat
- track uploaded image URLs in session data
- add R2 utilities and tests
- document cleanup logic in README, ARCHITECTURE and VIBE_CHECK
- note new behaviour in CHANGELOG

## Testing
- `npm test`