### PR TITLE
Update admin route to subpath

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -222,7 +222,7 @@ triggers = { crons = ["0 * * * *"] }
 [env.admin]
 main = "workers/admin.js"
 name = "tataoro-admin"
-route = "https://admin.tataoro.com/*"
+route = "https://wa.tataoro.com/admin*"
 
 [vars]
 EMAIL_ENABLED = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.4.1 - Update Admin Route
+- Admin dashboard now served under `https://wa.tataoro.com/admin` instead of the `admin.tataoro.com` subdomain.
+
 ## v1.4.0 - Admin Dashboard Worker
 - Added `workers/admin.js` providing a lightweight web UI for listing sessions, viewing details, and resetting conversations.
 - Updated `wrangler.toml` with `[env.admin]` configuration.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For detailed prompt configuration, see [VIBE_PROMPT.md](docs/issues/05-closed/VI
 - Scheduled WhatsApp nudges for stalled consultations
 - Stateless GET `/summary/:conversationId` endpoint for dynamic, read-only HTML consultation summaries (chat messages, metadata, images) without separate storage.
 - Scheduler worker (`workers/scheduler.js`) with hourly cron checks
-- Lightweight admin portal (`workers/admin.js`) to browse sessions and reset them
+- Lightweight admin portal (`workers/admin.js`) to browse sessions and reset them (available at `/admin` under the WhatsApp domain)
 
 ## Setup
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -39,7 +39,7 @@ triggers = { crons = ["0 * * * *"] }
 [env.admin]
 main = "workers/admin.js"
 name = "tataoro-admin"
-route = "https://admin.tataoro.com/*"
+route = "https://wa.tataoro.com/admin*"
 
 [vars]
 EMAIL_ENABLED = true


### PR DESCRIPTION
## Summary
- serve admin worker at `/admin` under wa.tataoro.com
- document new route in README and ARCHITECTURE
- note change in CHANGELOG

## Testing
- `npm test`
