### PR TITLE
Refactor routes for multi-channel support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,7 +7,8 @@
 ```bash
 tataoro-assistant/
 ├── workers/                  # Edge runtimes for request handling and background jobs
-│   ├── whatsapp.js           # Handles incoming WhatsApp webhook from Twilio
+│   ├── whatsapp-incoming.js  # Handles incoming WhatsApp webhook from Twilio
+│   ├── summary.js           # Public summary and image viewer
 │   ├── doc-sync.js           # Fetches GitHub files and updates embeddings
 │   ├── upload-hook.js        # (Optional) GitHub webhook to trigger doc sync
 │   ├── scheduler.js          # Cron-triggered tasks: email summaries & WhatsApp nudges
@@ -184,7 +185,7 @@ Update your `wrangler.toml` to define environments for each Worker:
 ```toml
 name = "tataoro-gpt"
 compatibility_date = "2025-05-18"
-main = "workers/whatsapp.js"
+main = "workers/whatsapp-incoming.js"
 
 [[kv_namespaces]]
 binding = "CHAT_HISTORY"
@@ -200,9 +201,17 @@ binding = "DOC_KNOWLEDGE"
 id = "c4281158fd7346fdac1f9e10bc092079"
 
 [env.whatsapp]
-main = "workers/whatsapp.js"
+main = "workers/whatsapp-incoming.js"
 name = "tataoro-whatsapp"
-route = "https://wa.tataoro.com/*"
+route = "https://wa.tataoro.com/whatsapp/incoming"
+
+[env.summary]
+main = "workers/summary.js"
+name = "tataoro-summary"
+routes = [
+  "https://wa.tataoro.com/summary*",
+  "https://wa.tataoro.com/images/*"
+]
 
 [env.docsync]
 main = "workers/doc-sync.js"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.4.2 - Multi-channel route refactor
+- Adopted `/whatsapp/incoming` route and new summary worker.
+- Standardized storage keys using channel prefixes.
 ## v1.4.1 - Update Admin Route
 - Admin dashboard now served under `https://wa.tataoro.com/admin` instead of the `admin.tataoro.com` subdomain.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Cloudflare Worker webhook handler for Twilio WhatsApp messages, powered by OpenA
 
 This repository uses a multi-worker setup to separate concerns across different Cloudflare Workers:
 
-- **WhatsApp handler** (`workers/whatsapp.js`): handles incoming Twilio WhatsApp messages and generates GPT-4o-mini responses.
+- **WhatsApp handler** (`workers/whatsapp-incoming.js`): handles incoming Twilio WhatsApp messages and generates GPT-4o-mini responses.
 - **Doc-sync worker** (`workers/doc-sync.js`): fetches GitHub markdown files, splits content, generates embeddings, and stores them in KV.
 - **Upload-hook worker** (`workers/upload-hook.js`): GitHub webhook endpoint to trigger automatic document sync.
 - **Admin dashboard worker** (`workers/admin.js`): lightweight web UI to inspect and reset sessions.
@@ -38,10 +38,10 @@ For detailed prompt configuration, see [VIBE_PROMPT.md](docs/issues/05-closed/VI
 Ensure your `wrangler.toml` defines the default `main` entry point for the WhatsApp worker:
 
 ```toml
-main = "workers/whatsapp.js"
+main = "workers/whatsapp-incoming.js"
 
 [env.whatsapp]
-main = "workers/whatsapp.js"
+main = "workers/whatsapp-incoming.js"
 ```
 
 Configure your `wrangler.toml` with top-level KV namespaces and R2 bucket bindings:
@@ -124,6 +124,6 @@ npm test
 
 ## Usage
 
-- Configure your Twilio WhatsApp webhook to point to the `whatsapp` worker endpoint (e.g., `https://<your-domain>/`).
+- Configure your Twilio WhatsApp webhook to point to `/whatsapp/incoming` (e.g., `https://<your-domain>/whatsapp/incoming`).
 - Trigger document synchronization by POSTing to the `doc-sync` worker or via a scheduled cron/CLI.
 - Point your GitHub webhook to the `upload-hook` worker to automate updates.

--- a/docs/VIBE_CHECK.md
+++ b/docs/VIBE_CHECK.md
@@ -6,7 +6,8 @@ This checklist verifies that the generated Cloudflare Worker correctly implement
 
 ## ✅ Core File Structure
 
-- [x] `workers/whatsapp.js` exists and uses the Cloudflare `fetch` handler pattern
+- [x] `workers/whatsapp-incoming.js` exists and uses the Cloudflare `fetch` handler pattern
+- [x] `workers/summary.js` exists for `/summary/:conversationId` and `/images/*`
 - [x] `workers/doc-sync.js` exists
 - [x] `workers/upload-hook.js` exists
 - [x] Implements shareable summary endpoint GET `/summary/:conversationId` in `workers/whatsapp.js`
@@ -116,3 +117,5 @@ https://wa.me/16895292934?text=<encoded summary>
 - [x] Endpoint URL set as the webhook in Twilio for the WhatsApp number
 
 ---
+- [x] Routes follow `/[channel]/[service]` pattern (e.g., `/whatsapp/incoming`)
+- [x] Keys follow `[datastore]/[namespace]/[platform]:[id]/...` format

--- a/docs/conventions/route-and-key-structure.md
+++ b/docs/conventions/route-and-key-structure.md
@@ -1,0 +1,20 @@
+# Route and Key Structure
+
+This project organizes all endpoints by channel first, then service. Incoming message webhooks live under `/[channel]/incoming`.
+
+Examples:
+
+- `/whatsapp/incoming`
+- `/webchat/incoming`
+
+Public utilities like summaries remain platform agnostic:
+
+- `/summary/:conversationId`
+
+Storage keys follow a `datastore/namespace/platform:identifier/...` pattern to enable prefix queries across multiple channels.
+
+Examples:
+
+- `kv/chat/whatsapp:+14155551234/history`
+- `kv/docs/github:klappy/docs/file.md/chunk3`
+- `r2/media/whatsapp:+14155551234/1700000000000-0.jpeg`

--- a/shared/storageKeys.js
+++ b/shared/storageKeys.js
@@ -1,0 +1,16 @@
+export const CHAT_PREFIX = 'kv/chat/';
+export function chatHistoryKey(platform, id) {
+  return `${CHAT_PREFIX}${platform}:${id}/history`;
+}
+export function chatHistoryPrefix(platform) {
+  return `${CHAT_PREFIX}${platform}:`;
+}
+export function mediaPrefix(platform, id) {
+  return `r2/media/${platform}:${id}/`;
+}
+export function mediaObjectKey(platform, id, name) {
+  return `${mediaPrefix(platform, id)}${name}`;
+}
+export function docChunkKey(owner, repo, path, index) {
+  return `kv/docs/github:${owner}/${repo}/${path}/chunk${index}`;
+}

--- a/workers/doc-sync.js
+++ b/workers/doc-sync.js
@@ -1,5 +1,6 @@
 import { embedText } from '../shared/embeddings.js';
 import { chunkText } from '../shared/chunker.js';
+import { docChunkKey } from '../shared/storageKeys.js';
 
 export default {
   async fetch(request, env) {
@@ -17,7 +18,7 @@ export default {
       const chunks = chunkText(content);
       const embeddings = await embedText(chunks, env.OPENAI_API_KEY);
       for (let i = 0; i < embeddings.length; i++) {
-        const key = `${owner}/${repo}/${path}/chunk${i}`;
+        const key = docChunkKey(owner, repo, path, i);
         await env.DOC_KNOWLEDGE.put(key, JSON.stringify({ chunk: chunks[i], embedding: embeddings[i] }));
       }
       return new Response('Document synced', { status: 200 });

--- a/workers/summary.js
+++ b/workers/summary.js
@@ -1,0 +1,64 @@
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const baseUrl = url.origin;
+    if (request.method === 'GET' && url.pathname.startsWith('/images/')) {
+      const key = decodeURIComponent(url.pathname.slice('/images/'.length));
+      const object = await env.MEDIA_BUCKET.get(key, { type: 'stream' });
+      if (!object) return new Response('Not Found', { status: 404 });
+      const headers = {};
+      if (object.httpMetadata?.contentType) {
+        headers['Content-Type'] = object.httpMetadata.contentType;
+      }
+      return new Response(object.body, { headers });
+    }
+    if (request.method === 'GET' && url.pathname.startsWith('/summary/')) {
+      const rawId = decodeURIComponent(url.pathname.slice('/summary/'.length));
+      let phone = rawId;
+      try {
+        const decoded = atob(rawId);
+        if (decoded.startsWith('whatsapp:+')) phone = decoded;
+      } catch {}
+      const sessionKey = `kv/chat/${phone}/history`;
+      const stored = await env.CHAT_HISTORY.get(sessionKey, { type: 'json' });
+      if (!stored) return new Response('Not found', { status: 404, headers: { 'Content-Type': 'text/plain;charset=UTF-8' } });
+      const session = stored;
+      const { objects: objs } = await env.MEDIA_BUCKET.list({ prefix: `r2/media/${phone}/` });
+      const htmlParts = [];
+      htmlParts.push('<!DOCTYPE html><html><head><meta charset="utf-8"><title>Consultation Summary</title><style>body{font-family:sans-serif;max-width:600px;margin:auto;padding:1em}.message{margin-bottom:1em}.user{color:#0066cc}.assistant{color:#008000}.metadata{font-size:.9em;color:#666}img{max-width:100%;display:block;margin:0.5em 0}</style></head><body><h1>Consultation Summary</h1>');
+      htmlParts.push(`<div class="metadata"><p>Progress status: ${escapeXml(session.progress_status)}</p><p>Last active: ${escapeXml(new Date(session.last_active * 1000).toLocaleString())}</p>${session.summary ? `<p>Summary: ${escapeXml(session.summary)}</p>` : ''}</div>`);
+      htmlParts.push('<div class="messages">');
+      for (const msg of session.history || []) {
+        htmlParts.push(`<div class="message ${msg.role}"><strong>${escapeXml(msg.role)}:</strong> `);
+        if (typeof msg.content === 'string') {
+          htmlParts.push(escapeXml(msg.content));
+        } else if (Array.isArray(msg.content)) {
+          for (const entry of msg.content) {
+            if (entry.type === 'text' && entry.text) htmlParts.push(escapeXml(entry.text));
+            if (entry.type === 'image_url' && entry.image_url?.url) htmlParts.push(`<img src="${escapeXml(entry.image_url.url)}">`);
+          }
+        }
+        htmlParts.push('</div>');
+      }
+      htmlParts.push('</div>');
+      if (objs?.length) {
+        htmlParts.push('<h2>Uploaded Images</h2>');
+        for (const obj of objs) {
+          htmlParts.push(`<img src="${baseUrl}/images/${encodeURIComponent(obj.key)}">`);
+        }
+      }
+      htmlParts.push('</body></html>');
+      return new Response(htmlParts.join(''), { headers: { 'Content-Type': 'text/html;charset=UTF-8' } });
+    }
+    return new Response('Not Found', { status: 404 });
+
+    function escapeXml(unsafe) {
+      return unsafe
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+    }
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,7 @@
 
 name = "tataoro-gpt"
 compatibility_date = "2025-05-18"
-main = "workers/whatsapp.js"
+main = "workers/whatsapp-incoming.js"
 
 [[kv_namespaces]]
 binding = "CHAT_HISTORY"
@@ -37,9 +37,17 @@ name = "tataoro-admin"
 route = "https://wa.tataoro.com/admin*"
 
 [env.whatsapp]
-main = "workers/whatsapp.js"
+main = "workers/whatsapp-incoming.js"
 name = "tataoro-whatsapp"
-route = "https://wa.tataoro.com/*"
+route = "https://wa.tataoro.com/whatsapp/incoming"
+
+[env.summary]
+main = "workers/summary.js"
+name = "tataoro-summary"
+routes = [
+  "https://wa.tataoro.com/summary*",
+  "https://wa.tataoro.com/images/*"
+]
 
 [vars]
 EMAIL_ENABLED = true


### PR DESCRIPTION
## Summary
- rename WhatsApp worker to `whatsapp-incoming.js`
- add new `summary` worker and route config
- enforce channel prefixes with shared `storageKeys` helpers
- update admin and scheduler to use new key structure
- document route and key conventions

## Testing
- `npm test`