### PR TITLE
Implement new key naming for R2 and KV

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,7 +60,7 @@ This document describes the architecture of the AI-powered WhatsApp consultation
 
 - Stores per-user session history to preserve multi-turn context
 - Retention: 24-hour TTL
-- Memory key: `chat_history:<phoneNumber>`
+ - KV key: `whatsapp:+<phoneNumber>/history.json`
 - Supports resetting conversation when users send reset keywords ("reset", "clear", "start over", "new consultation")
   - Uploaded R2 images are deleted during reset to avoid orphaned media
 - Stores session metadata alongside history (progress_status, last_active, summary_email_sent, nudge_sent, summary, r2Urls)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For detailed prompt configuration, see [VIBE_PROMPT.md](docs/issues/05-closed/VI
 
 - Accept incoming WhatsApp messages (text & images) from Twilio
 - Short-term memory with KV storage (`CHAT_HISTORY`)
+- KV keys use a concise format like `whatsapp:+14155551234/history.json`
 - Reset conversation via keywords ("reset", "clear", "start over", "new consultation") which also removes any uploaded photos from R2
 - System prompt & chat history injection for GPT-4o-mini
 - GPT-4o-mini vision support for understanding images

--- a/docs/VIBE_CHECK.md
+++ b/docs/VIBE_CHECK.md
@@ -11,6 +11,7 @@ This checklist verifies that the generated Cloudflare Worker correctly implement
 - [x] `workers/doc-sync.js` exists
 - [x] `workers/upload-hook.js` exists
 - [x] Implements shareable summary endpoint GET `/summary/:conversationId` in `workers/whatsapp.js`
+- [x] Uses key names like `whatsapp:+14155551234/history.json` and `whatsapp:+14155551234/1700000000000-0.jpeg`
 
 ```js
 export default {

--- a/docs/conventions/route-and-key-structure.md
+++ b/docs/conventions/route-and-key-structure.md
@@ -11,10 +11,10 @@ Public utilities like summaries remain platform agnostic:
 
 - `/summary/:conversationId`
 
-Storage keys follow a `datastore/namespace/platform:identifier/...` pattern to enable prefix queries across multiple channels.
+Storage keys are scoped by channel and identifier, without extra prefixes.
 
 Examples:
 
-- `kv/chat/whatsapp:+14155551234/history`
+- `whatsapp:+14155551234/history.json`
 - `kv/docs/github:klappy/docs/file.md/chunk3`
-- `r2/media/whatsapp:+14155551234/1700000000000-0.jpeg`
+- `whatsapp:+14155551234/1700000000000-0.jpeg`

--- a/shared/storageKeys.js
+++ b/shared/storageKeys.js
@@ -1,12 +1,11 @@
-export const CHAT_PREFIX = 'kv/chat/';
 export function chatHistoryKey(platform, id) {
-  return `${CHAT_PREFIX}${platform}:${id}/history`;
+  return `${platform}:${id}/history.json`;
 }
 export function chatHistoryPrefix(platform) {
-  return `${CHAT_PREFIX}${platform}:`;
+  return `${platform}:`;
 }
 export function mediaPrefix(platform, id) {
-  return `r2/media/${platform}:${id}/`;
+  return `${platform}:${id}/`;
 }
 export function mediaObjectKey(platform, id, name) {
   return `${mediaPrefix(platform, id)}${name}`;

--- a/workers/summary.js
+++ b/workers/summary.js
@@ -19,11 +19,12 @@ export default {
         const decoded = atob(rawId);
         if (decoded.startsWith('whatsapp:+')) phone = decoded;
       } catch {}
-      const sessionKey = `kv/chat/${phone}/history`;
+      const { chatHistoryKey, mediaPrefix } = await import('../shared/storageKeys.js');
+      const sessionKey = chatHistoryKey('whatsapp', phone);
       const stored = await env.CHAT_HISTORY.get(sessionKey, { type: 'json' });
       if (!stored) return new Response('Not found', { status: 404, headers: { 'Content-Type': 'text/plain;charset=UTF-8' } });
       const session = stored;
-      const { objects: objs } = await env.MEDIA_BUCKET.list({ prefix: `r2/media/${phone}/` });
+      const { objects: objs } = await env.MEDIA_BUCKET.list({ prefix: mediaPrefix('whatsapp', phone) });
       const htmlParts = [];
       htmlParts.push('<!DOCTYPE html><html><head><meta charset="utf-8"><title>Consultation Summary</title><style>body{font-family:sans-serif;max-width:600px;margin:auto;padding:1em}.message{margin-bottom:1em}.user{color:#0066cc}.assistant{color:#008000}.metadata{font-size:.9em;color:#666}img{max-width:100%;display:block;margin:0.5em 0}</style></head><body><h1>Consultation Summary</h1>');
       htmlParts.push(`<div class="metadata"><p>Progress status: ${escapeXml(session.progress_status)}</p><p>Last active: ${escapeXml(new Date(session.last_active * 1000).toLocaleString())}</p>${session.summary ? `<p>Summary: ${escapeXml(session.summary)}</p>` : ''}</div>`);


### PR DESCRIPTION
## Summary
- simplify KV and R2 key generation
- reference new keys across WhatsApp summary worker
- update docs with concise key naming examples

## Testing
- `npm test`