### PR TITLE
Add dedicated images worker

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -178,6 +178,12 @@ This ensures cleanup uses the complete `whatsapp:+phone/...` prefix when deletin
 
 ---
 
+## Public Media Delivery
+
+A dedicated `images` Worker serves public R2-hosted objects. It accepts only `GET` requests and returns the object's body with the original `Content-Type`. Other Workers must not handle `/images/*`.
+
+---
+
 ## 🛠️ wrangler.toml (Multi-Worker Setup)
 
 Update your `wrangler.toml` to define environments for each Worker:
@@ -210,8 +216,12 @@ main = "workers/summary.js"
 name = "tataoro-summary"
 routes = [
   "https://wa.tataoro.com/summary*",
-  "https://wa.tataoro.com/images/*"
 ]
+
+[env.images]
+main = "workers/images.js"
+name = "tataoro-images"
+route = "https://wa.tataoro.com/images/*"
 
 [env.docsync]
 main = "workers/doc-sync.js"

--- a/README.md
+++ b/README.md
@@ -31,8 +31,18 @@ For detailed prompt configuration, see [VIBE_PROMPT.md](docs/issues/05-closed/VI
 - Scheduled timeout-based email summary for incomplete consultations
 - Scheduled WhatsApp nudges for stalled consultations
 - Stateless GET `/summary/:conversationId` endpoint for dynamic, read-only HTML consultation summaries (chat messages, metadata, images) without separate storage.
+- Dedicated `/images/*` worker serves public R2-hosted media
 - Scheduler worker (`workers/scheduler.js`) with hourly cron checks
 - Lightweight admin portal (`workers/admin.js`) to browse sessions and reset them (available at `/admin` under the WhatsApp domain)
+
+### Public Media Delivery
+
+Images uploaded via WhatsApp are stored in R2. The `images` Worker exposes them at
+`https://wa.tataoro.com/images/{encodedKey}`. Example:
+
+```js
+const url = `${WHATSAPP_BASE_URL}/images/${encodeURIComponent(key)}`;
+```
 
 ## Setup
 

--- a/docs/VIBE_CHECK.md
+++ b/docs/VIBE_CHECK.md
@@ -7,7 +7,8 @@ This checklist verifies that the generated Cloudflare Worker correctly implement
 ## ✅ Core File Structure
 
 - [x] `workers/whatsapp-incoming.js` exists and uses the Cloudflare `fetch` handler pattern
-- [x] `workers/summary.js` exists for `/summary/:conversationId` and `/images/*`
+- [x] `workers/summary.js` exists for `/summary/:conversationId`
+- [x] `workers/images.js` exists for `/images/*`
 - [x] `workers/doc-sync.js` exists
 - [x] `workers/upload-hook.js` exists
 - [x] Implements shareable summary endpoint GET `/summary/:conversationId` in `workers/whatsapp.js`

--- a/docs/decisions/015-dedicated-image-worker.md
+++ b/docs/decisions/015-dedicated-image-worker.md
@@ -1,0 +1,35 @@
+# ADR 015: Dedicated Worker for Public Image Access
+
+## Status
+
+Accepted
+
+## Context
+
+Greedy routing patterns previously caused `/images/*` requests to be handled by other workers. This led to 405 errors and invalid image URLs when OpenAI tried to fetch uploaded photos.
+
+## Reason
+
+Prevent routing shadowing by greedy match-all routes and isolate risk domains.
+
+## Decision
+
+Introduce a separate `images` worker that serves R2-hosted objects via `GET /images/*`. It isolates image delivery from the WhatsApp and summary workers and prevents route shadowing.
+
+## Alternatives Considered
+
+- Serving images directly from `whatsapp-incoming.js`
+- Generating signed R2 URLs
+- Using an image proxy service
+
+## Outcome
+
+A consistent routing pattern where `/images/*` always maps to the `tataoro-images` worker. The architecture is simpler and image access is easier to test and observe.
+
+## Date
+
+2025-05-21
+
+## Scope
+
+All `wa.tataoro.com` workers

--- a/workers/images.js
+++ b/workers/images.js
@@ -1,0 +1,19 @@
+// Public images worker
+// Do not handle /images/* elsewhere
+export default {
+  async fetch(request, env) {
+    if (request.method !== 'GET') {
+      return new Response('Method Not Allowed', { status: 405 });
+    }
+    const url = new URL(request.url);
+    const key = decodeURIComponent(url.pathname.slice('/images/'.length));
+    if (!key) return new Response('Not Found', { status: 404 });
+    const object = await env.MEDIA_BUCKET.get(key, { type: 'stream' });
+    if (!object) return new Response('Not Found', { status: 404 });
+    const headers = {};
+    if (object.httpMetadata?.contentType) {
+      headers['Content-Type'] = object.httpMetadata.contentType;
+    }
+    return new Response(object.body, { headers });
+  },
+};

--- a/workers/summary.js
+++ b/workers/summary.js
@@ -2,16 +2,7 @@ export default {
   async fetch(request, env) {
     const url = new URL(request.url);
     const baseUrl = url.origin;
-    if (request.method === 'GET' && url.pathname.startsWith('/images/')) {
-      const key = decodeURIComponent(url.pathname.slice('/images/'.length));
-      const object = await env.MEDIA_BUCKET.get(key, { type: 'stream' });
-      if (!object) return new Response('Not Found', { status: 404 });
-      const headers = {};
-      if (object.httpMetadata?.contentType) {
-        headers['Content-Type'] = object.httpMetadata.contentType;
-      }
-      return new Response(object.body, { headers });
-    }
+    // Do not handle /images/* here — served by dedicated images worker
     if (request.method === 'GET' && url.pathname.startsWith('/summary/')) {
       const rawId = decodeURIComponent(url.pathname.slice('/summary/'.length));
       let phone = rawId;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,9 +45,13 @@ route = "https://wa.tataoro.com/whatsapp/incoming"
 main = "workers/summary.js"
 name = "tataoro-summary"
 routes = [
-  "https://wa.tataoro.com/summary*",
-  "https://wa.tataoro.com/images/*"
+  "https://wa.tataoro.com/summary*"
 ]
+
+[env.images]
+main = "workers/images.js"
+name = "tataoro-images"
+route = "https://wa.tataoro.com/images/*"
 
 [vars]
 EMAIL_ENABLED = true


### PR DESCRIPTION
## Summary
- add images worker for `/images/*`
- document new worker in ADR 015
- update architecture guide for public media delivery
- update README with image worker example
- update VIBE_CHECK checklist
- remove images route from summary worker
- register new worker in wrangler config

## Testing
- `npm test`