### PR TITLE
Implement assistant-led summary handoff

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,6 +94,12 @@ User sends message via WhatsApp/SMS → Twilio Webhook → Cloudflare Worker
 → User receives updated message in WhatsApp or SMS
 ```
 
+Simple diagram:
+
+```
+System prompt → [session summary + link] → history → GPT → reply to user
+```
+
 ---
 
 ## 🧠 System Prompt Logic
@@ -106,6 +112,7 @@ The assistant uses a system prompt extracted into the `shared/systemPrompt.js` m
 - Detects unrealistic expectations (e.g., instant curl restoration)
 - Produces a WhatsApp-handoff summary when the consultation concludes
 - User phone number is injected into the prompt using `{{USER_PHONE}}` at runtime
+- The worker injects any saved summary and summary link back into the GPT context so the assistant can reference them naturally
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.4.6 - Assistant-Led Summary Handoff
+
+- Inject session summary and link into GPT context instead of overriding replies
+- Removed regex-based summary detection
+- Updated scheduler and email triggers to set `summary-ready` status
+- Documentation updates for new flow
+
 ## v1.4.5 - Session Key Normalization
 
 - Added `normalizePhoneNumber` helper and hardened `chatHistoryKey`.

--- a/__tests__/promptInjection.test.js
+++ b/__tests__/promptInjection.test.js
@@ -38,4 +38,22 @@ describe('phone injection into system prompt', () => {
     assert.ok(captured[0].content.includes('whatsapp:+1234567890'));
     assert.ok(!captured[0].content.includes('{{USER_PHONE}}'));
   });
+
+  it('injects stored summary and link into GPT context', async () => {
+    const env = {
+      OPENAI_API_KEY: 'k',
+      TWILIO_ACCOUNT_SID: 'id',
+      TWILIO_AUTH_TOKEN: 'tok',
+      CHAT_HISTORY: {
+        get: async () => ({ history: [], summary: 'past summary', progress_status: 'summary-ready' }),
+        put: async () => {},
+      },
+      MEDIA_BUCKET: { put: async () => {}, list: async () => ({ objects: [] }) },
+    };
+    const ctx = { waitUntil() {} };
+    await handleWhatsAppRequest(makeRequest(), env, ctx);
+    assert.strictEqual(captured[1].role, 'assistant');
+    assert.strictEqual(captured[1].content, 'past summary');
+    assert.ok(captured[2].content.includes('/summary/whatsapp:+1234567890'));
+  });
 });

--- a/docs/VIBE_CHECK.md
+++ b/docs/VIBE_CHECK.md
@@ -84,6 +84,7 @@ export default {
 https://wa.me/16895292934?text=<encoded summary>
 ```
   - [x] Summary and handoff links include the client's phone number
+  - [x] Worker passes stored summary and link back to GPT context instead of overriding GPT output with a regex
 
 ---
 

--- a/docs/architecture/openai-routing.md
+++ b/docs/architecture/openai-routing.md
@@ -32,14 +32,12 @@ const messages = [
 
 ---
 
-## 🧾 Summary Detection
+## 🧾 Summary Flow
 
 - Assistant is instructed to produce a structured Markdown summary
-- Worker detects summary handoff link in the assistant reply using
-  `summaryHandoffLinkRegex` (e.g., a wa.me link). When detected, the worker calls
-  `generateOrFetchSummary` to regenerate the summary with real R2 image URLs so
-  the inline message matches the emailed summary. It then sends the summary
-  email and upserts the Shopify customer record.
+- When a summary is generated (manually or via timeout email), it is stored in the session along with a shareable URL.
+- On each GPT request the worker injects this summary and link back into the messages array as `assistant` role entries.
+- This allows GPT to reference the summary naturally without any regex-based overrides.
 
 ---
 

--- a/shared/systemPrompt.js
+++ b/shared/systemPrompt.js
@@ -34,9 +34,11 @@ Then include this exact link format, with the correct client summary URL encoded
 
 \`<a href="https://wa.me/16895292934?text=Hi%20Tata!%20Here%20is%20my%20curl%20consultation%20summary:%20https%3A%2F%2Fwa.tataoro.com%2Fsummary%2Fwhatsapp%3A%2B{{USER_PHONE}}" target="_blank" rel="noopener noreferrer">Click here to send it to Tata via WhatsApp</a>\`
 
-⚠️ Replace the phone number in the summary link with the actual user's number.  
-⚠️ Do not include emojis inside the URL or inside the summary content.  
+⚠️ Replace the phone number in the summary link with the actual user's number.
+⚠️ Do not include emojis inside the URL or inside the summary content.
 ✅ The link must open in a **new tab/window**.
+
+After the summary is generated, the conversation will include a message with the link. Reference that context rather than injecting new links yourself.
 
 ---
 

--- a/workers/scheduler.js
+++ b/workers/scheduler.js
@@ -59,6 +59,7 @@ export default {
               })
             );
             session.summary_email_sent = true;
+            session.progress_status = 'summary-ready';
             await env.CHAT_HISTORY.put(key.name, JSON.stringify(session), { expirationTtl: 86400 });
           }
           if (!session.nudge_sent && now - lastActive > 7200) {


### PR DESCRIPTION
## Summary
- inject summary and handoff link into GPT context
- remove regex-based override logic
- mark sessions `summary-ready` when email or scheduler sends summary
- refine system prompt instructions
- document assistant-led flow in ARCHITECTURE and VIBE_CHECK
- test context injection for summary

## Testing
- `npm test`