### PR TITLE
Fix summary detection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.4.7 - Summary State Fix
+
+- Detect assistant-generated summaries in `whatsapp-incoming` and
+  update `progress_status` to `summary-ready`.
+- Added `extractSummaryFromReply` helper with tests.
+
 ## v1.4.6 - Assistant-Led Summary Handoff
 
 - Inject session summary and link into GPT context instead of overriding replies

--- a/__tests__/summaryParser.test.js
+++ b/__tests__/summaryParser.test.js
@@ -1,0 +1,23 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractSummaryFromReply } from '../shared/summary.js';
+
+describe('extractSummaryFromReply', () => {
+  it('detects and stores summary', () => {
+    const session = { progress_status: 'midway' };
+    const reply = '**Client Curl Discovery Summary for Tata Oro**\nDone';
+    const result = extractSummaryFromReply(reply, session);
+    assert.strictEqual(result, true);
+    assert.strictEqual(session.summary, reply);
+    assert.strictEqual(session.progress_status, 'summary-ready');
+  });
+
+  it('returns false when summary missing', () => {
+    const session = { progress_status: 'midway' };
+    const reply = 'Hello world';
+    const result = extractSummaryFromReply(reply, session);
+    assert.strictEqual(result, false);
+    assert.ok(!session.summary);
+    assert.strictEqual(session.progress_status, 'midway');
+  });
+});

--- a/shared/summary.js
+++ b/shared/summary.js
@@ -49,3 +49,20 @@ export async function generateOrFetchSummary({ env, session, phone, baseUrl }) {
   }
   return finalSummary;
 }
+
+/**
+ * Detect an assistant-generated summary and update the session in place.
+ *
+ * @param {string} assistantReply - Raw GPT response
+ * @param {object} session - Mutable session object
+ * @returns {boolean} True if a summary was detected
+ */
+export function extractSummaryFromReply(assistantReply, session) {
+  const summaryHeader = 'Client Curl Discovery Summary for Tata Oro';
+  if (assistantReply && assistantReply.includes(summaryHeader)) {
+    session.summary = assistantReply;
+    session.progress_status = 'summary-ready';
+    return true;
+  }
+  return false;
+}

--- a/workers/whatsapp-incoming.js
+++ b/workers/whatsapp-incoming.js
@@ -16,7 +16,7 @@ import { chatHistoryKey, mediaObjectKey, mediaPrefix, normalizePhoneNumber } fro
 import { chatCompletion } from '../shared/gpt.js';
 import { SYSTEM_PROMPT } from '../shared/systemPrompt.js';
 import { sendConsultationEmail } from '../shared/emailer.js';
-import { generateOrFetchSummary } from '../shared/summary.js';
+import { generateOrFetchSummary, extractSummaryFromReply } from '../shared/summary.js';
 import { deleteR2Objects, r2KeyFromUrl } from '../shared/r2.js';
 
 export async function handleWhatsAppRequest(request, env, ctx) {
@@ -198,6 +198,9 @@ export async function handleWhatsAppRequest(request, env, ctx) {
     }
 
     session.history.push({ role: 'assistant', content: assistantReply });
+
+    // Detect if GPT produced the final summary
+    extractSummaryFromReply(assistantReply, session);
 
     // Save session state with TTL
     await env.CHAT_HISTORY.put(sessionKey, JSON.stringify(session), { expirationTtl: 86400 });


### PR DESCRIPTION
## Summary
- detect assistant-generated summary from the reply
- update session status when summary is found
- add helper `extractSummaryFromReply`
- document change in CHANGELOG
- test the new helper

## Testing
- `npm test`