### PR TITLE
v1.4.8 shared summary html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.4.8 - Shared Summary Renderer
+
+- Extracted `renderSummaryHTML` for consistent email and page layout
+- Summary worker and emailer now reuse the same renderer
+- Email tests updated for HTML output
+
 ## v1.4.7 - Summary Detection Fix
 
 - Detect assistant-generated summary output and mark session `summary-ready`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For detailed prompt configuration, see [VIBE_PROMPT.md](docs/issues/05-closed/VI
 - Scheduled WhatsApp nudges for stalled consultations
 - Automatically detects when GPT sends the final summary and marks the session as `summary-ready`
 - Stateless GET `/summary/:conversationId` endpoint for dynamic, read-only HTML consultation summaries (chat messages, metadata, images) without separate storage.
+- Shared HTML renderer ensures email summaries match the public summary layout.
 - Dedicated `/images/*` route serves public R2-hosted media
 - Scheduler worker (`workers/scheduler.js`) with hourly cron checks
 - Lightweight admin portal (`workers/admin.js`) to browse sessions and reset them (available at `/admin` under the WhatsApp domain)

--- a/__tests__/emailer.test.js
+++ b/__tests__/emailer.test.js
@@ -34,10 +34,20 @@ describe('sendConsultationEmail', () => {
       EMAIL_PROVIDER: 'resend',
       RESEND_API_KEY: 'k',
       EMAIL_FROM: 'a@a.com',
-      EMAIL_TO: 'b@b.com'
+      EMAIL_TO: 'b@b.com',
+      WHATSAPP_BASE_URL: 'http://x'
     };
-    await sendConsultationEmail({ env, phone: '1', summary: 's' });
+    await sendConsultationEmail({
+      env,
+      phone: '1',
+      summary: 's',
+      history: [{ role: 'user', content: 'hi' }],
+      r2Urls: ['http://x/images/a.jpg']
+    });
     assert.strictEqual(fetchCalls.length, 1);
     assert.strictEqual(fetchCalls[0][0], 'https://api.resend.com/emails');
+    const body = JSON.parse(fetchCalls[0][1].body);
+    assert.ok(/hi/.test(body.html));
+    assert.ok(/http:\/\/x\/images\/a.jpg/.test(body.html));
   });
 });

--- a/__tests__/promptInjection.test.js
+++ b/__tests__/promptInjection.test.js
@@ -35,7 +35,7 @@ describe('phone injection into system prompt', () => {
     };
     const ctx = { waitUntil() {} };
     await handleWhatsAppRequest(makeRequest(), env, ctx);
-    assert.ok(captured[0].content.includes('whatsapp:+1234567890'));
+    assert.ok(captured[0].content.includes('whatsapp:%2B1234567890'));
     assert.ok(!captured[0].content.includes('{{USER_PHONE}}'));
   });
 

--- a/__tests__/summaryHtml.test.js
+++ b/__tests__/summaryHtml.test.js
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderSummaryHTML } from '../shared/summary.js';
+
+describe('renderSummaryHTML', () => {
+  it('renders history and images', () => {
+    const session = {
+      history: [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'hello' }
+      ],
+      summary: 'done',
+      progress_status: 'summary-ready',
+      last_active: 0
+    };
+    const html = renderSummaryHTML({
+      session,
+      mediaObjects: [{ key: 'a.jpg' }],
+      baseUrl: 'http://x'
+    });
+    assert.ok(/Consultation Summary/.test(html));
+    assert.ok(/hi/.test(html));
+    assert.ok(/http:\/\/x\/images\/a.jpg/.test(html));
+  });
+});

--- a/shared/summary.js
+++ b/shared/summary.js
@@ -49,3 +49,78 @@ export async function generateOrFetchSummary({ env, session, phone, baseUrl }) {
   }
   return finalSummary;
 }
+
+/**
+ * Render consultation history and summary to a single HTML string.
+ * Used for both the public summary page and summary emails so the
+ * layout remains consistent.
+ *
+ * @param {object} options
+ * @param {object} options.session - Session data with history and summary
+ * @param {Array} [options.mediaObjects] - Optional R2 objects to display
+ * @param {string} [options.phone] - Phone identifier used for image URLs
+ * @param {string} [options.baseUrl] - Base URL for public image links
+ * @returns {string}
+ */
+export function renderSummaryHTML({
+  session,
+  mediaObjects = [],
+  phone,
+  baseUrl,
+}) {
+  const escapeHtml = (unsafe) =>
+    String(unsafe)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&apos;");
+
+  const html = [];
+  html.push(
+    "<!DOCTYPE html><html><head><meta charset='utf-8'><title>Consultation Summary</title>"
+  );
+  html.push(
+    `<style>body{white-space:pre-line;font-family:-apple-system,BlinkMacSystemFont,sans-serif;max-width:600px;margin:auto;padding:1em;background-color:#ece5dd}h1{color:#075e54;font-size:1.5em;margin-bottom:0.5em}.metadata{font-size:.9em;color:#666;margin-bottom:1em}.bubble{border-radius:.4em;padding:.75em;margin:.5em 0;max-width:90%;clear:both}.user{background-color:#dcf8c6;align-self:flex-end;float:right}.assistant{background-color:#fff;align-self:flex-start;float:left}.summary{background-color:#fff8e1;padding:1em;margin:1em 0;border-left:4px solid #ffeb3b;white-space:pre-line}img{max-width:100%;border-radius:.3em;margin:.25em 0}a{color:#128c7e;word-break:break-word}</style></head><body><h1>Consultation Summary</h1>`
+  );
+
+  html.push(
+    `<div class="metadata"><p>Progress status: ${
+      escapeHtml(session.progress_status || "")
+    }</p><p>Last active: ${escapeHtml(
+      session.last_active
+        ? new Date(session.last_active * 1000).toLocaleString()
+        : ""
+    )}</p>${
+      session.summary ? `<p class="summary">${escapeHtml(session.summary)}</p>` : ""
+    }</div>`
+  );
+
+  html.push('<div class="messages">');
+  for (const msg of session.history || []) {
+    html.push(`<div class="message bubble ${msg.role}"><strong>${msg.role}:</strong> `);
+    if (typeof msg.content === "string") {
+      html.push(escapeHtml(msg.content));
+    } else if (Array.isArray(msg.content)) {
+      for (const entry of msg.content) {
+        if (entry.type === "text" && entry.text) html.push(escapeHtml(entry.text));
+        if (entry.type === "image_url" && entry.image_url?.url)
+          html.push(`<img src="${escapeHtml(entry.image_url.url)}">`);
+      }
+    }
+    html.push("</div>");
+  }
+  html.push("</div>");
+
+  if (mediaObjects.length) {
+    html.push("<h2>Uploaded Images</h2>");
+    for (const obj of mediaObjects) {
+      const encoded = encodeURIComponent(obj.key);
+      const url = baseUrl ? `${baseUrl}/images/${encoded}` : `images/${encoded}`;
+      html.push(`<img src="${url}">`);
+    }
+  }
+
+  html.push("</body></html>");
+  return html.join("");
+}


### PR DESCRIPTION
## Summary
- reuse summary HTML rendering across emailer and summary endpoint
- update scheduler/whatsapp workers to use the shared renderer
- expand email tests for HTML payload
- add unit test for renderSummaryHTML
- document shared renderer in README and CHANGELOG

## Testing
- `npm test`