### PR TITLE
Redesigned admin session UI

### DIFF
--- a/__tests__/adminHtml.test.js
+++ b/__tests__/adminHtml.test.js
@@ -1,0 +1,27 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderAdminSessionHTML } from '../shared/summary.js';
+
+describe('renderAdminSessionHTML', () => {
+  it('renders messages and summary', () => {
+    const session = {
+      history: [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'hello' }
+      ],
+      summary: 'done',
+      progress_status: 'summary-ready',
+      last_active: 0,
+      name: 'Tata',
+      email: 'tata@example.com'
+    };
+    const html = renderAdminSessionHTML({ session, mediaObjects: [{ key: 'a.jpg' }], baseUrl: 'http://x', phone: '+1' });
+    assert.ok(/hi/.test(html));
+    assert.ok(/hello/.test(html));
+    assert.ok(/done/.test(html));
+    assert.ok(/http:\/\/x\/images\/a.jpg/.test(html));
+    assert.ok(/Tata/.test(html));
+    assert.ok(/tata@example.com/.test(html));
+  });
+});
+

--- a/shared/summary.js
+++ b/shared/summary.js
@@ -122,5 +122,51 @@ export function renderSummaryHTML({
   }
 
   html.push("</body></html>");
+
   return html.join("");
+
+}
+export function renderAdminSessionHTML({ session, mediaObjects = [], phone, baseUrl }) {
+  const escapeHtml = (s) =>
+    String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&apos;");
+  const html = [];
+  html.push("<!DOCTYPE html><html><head><meta charset='utf-8'><title>Session " + escapeHtml(phone || '') + "</title>");
+  html.push(`<style>body{white-space:pre-line;font-family:-apple-system,BlinkMacSystemFont,sans-serif;max-width:600px;margin:auto;padding:1em;background-color:#ece5dd}h1{color:#075e54;font-size:1.5em;margin-bottom:.5em}.metadata{font-size:.9em;color:#666;margin-bottom:1em}.bubble{border-radius:.4em;padding:.75em;margin:.5em 0;max-width:90%;clear:both}.user{background-color:#dcf8c6;align-self:flex-end;float:right}.assistant{background-color:#fff;align-self:flex-start;float:left}.summary{background-color:#fff8e1;padding:1em;margin:1em 0;border-left:4px solid #ffeb3b;white-space:pre-line}img{max-width:100%;border-radius:.3em;margin:.25em 0}a{color:#128c7e;word-break:break-word}</style></head><body>`);
+  html.push(`<h1>${escapeHtml(phone || '')}</h1>`);
+  html.push('<div class="metadata">');
+  if (session.name) html.push(`<p>Name: ${escapeHtml(session.name)}</p>`);
+  if (session.email) html.push(`<p>Email: ${escapeHtml(session.email)}</p>`);
+  html.push(`<p>Progress status: ${escapeHtml(session.progress_status || '')}</p>`);
+  html.push(`<p>Last active: ${escapeHtml(session.last_active ? new Date(session.last_active * 1000).toLocaleString() : '')}</p>`);
+  html.push('</div>');
+  if (session.summary) html.push(`<div class="summary">${escapeHtml(session.summary)}</div>`);
+  html.push('<div class="messages">');
+  for (const msg of session.history || []) {
+    html.push(`<div class="message bubble ${msg.role}"><strong>${msg.role}:</strong> `);
+    if (typeof msg.content === 'string') {
+      html.push(escapeHtml(msg.content));
+    } else if (Array.isArray(msg.content)) {
+      for (const entry of msg.content) {
+        if (entry.type === 'text' && entry.text) html.push(escapeHtml(entry.text));
+        if (entry.type === 'image_url' && entry.image_url?.url) html.push(`<img src="${escapeHtml(entry.image_url.url)}">`);
+      }
+    }
+    html.push('</div>');
+  }
+  html.push('</div>');
+  if (mediaObjects.length) {
+    html.push('<h2>Uploaded Images</h2>');
+    for (const obj of mediaObjects) {
+      const encoded = encodeURIComponent(obj.key);
+      const url = baseUrl ? `${baseUrl}/images/${encoded}` : `images/${encoded}`;
+      html.push(`<img src="${url}">`);
+    }
+  }
+  html.push('</body></html>');
+  return html.join('');
 }

--- a/workers/scheduler.js
+++ b/workers/scheduler.js
@@ -45,6 +45,7 @@ export default {
           ) {
             const phone = normalizePhoneNumber(key.name.slice(chatHistoryPrefix('whatsapp').length));
             const summary = await generateOrFetchSummary({ env, session, phone });
+            session.summary = summary;
             const { objects } = await env.MEDIA_BUCKET.list({ prefix: mediaPrefix('whatsapp', phone) });
             const photoUrls = (objects || []).map(obj =>
               `${env.WHATSAPP_BASE_URL}/images/${encodeURIComponent(obj.key)}`


### PR DESCRIPTION
## Summary
- highlight summary-ready sessions on index
- add new `renderAdminSessionHTML` helper
- persist generated summaries
- improve `/admin/sessions/:phone` layout
- test admin HTML rendering

## Testing
- `npm test`