### PR TITLE
Extend chat history TTL to one month

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,7 +61,7 @@ This document describes the architecture of the AI-powered WhatsApp consultation
 ### 4. **Cloudflare KV (Binding: `CHAT_HISTORY`)**
 
 - Stores per-user session history to preserve multi-turn context
-- Retention: 24-hour TTL
+- Retention: one-month TTL
  - KV key: `whatsapp:+<phoneNumber>/history.json`
 - Supports resetting conversation when users send reset keywords ("reset", "clear", "start over", "new consultation")
   - Uploaded R2 images are deleted during reset to avoid orphaned media

--- a/docs/chatHistory.schema.md
+++ b/docs/chatHistory.schema.md
@@ -33,7 +33,7 @@ interface ChatHistorySession {
 2. **Mutation** – Incoming messages append to `history`, media URLs are collected in `r2Urls`, and `last_active` is refreshed.
 3. **Email Trigger** – When the user sends `"send email"` or the scheduler detects inactivity, `generateOrFetchSummary` builds the summary and `sendConsultationEmail` dispatches it, setting `summary_email_sent` and `progress_status` accordingly.
 4. **Summary Detection** – If GPT replies with a message starting with `"Client Curl Discovery Summary for Tata Oro"`, that reply becomes the `summary` and the session is marked `summary-ready`.
-5. **Storage** – After each update, the object is persisted back to KV with a TTL of 24 hours.
+5. **Storage** – After each update, the object is persisted back to KV with a TTL of one month (30 days).
 
 ## Example (Summary Ready)
 ```json

--- a/workers/admin.js
+++ b/workers/admin.js
@@ -84,7 +84,8 @@ export async function handleAdminRequest(request, env) {
       const summary = await generateOrFetchSummary({ env, session, phone, baseUrl: base });
       session.summary = summary;
       session.progress_status = 'summary-ready';
-      await env.CHAT_HISTORY.put(sessionKey, JSON.stringify(session), { expirationTtl: 86400 });
+      // Extend session retention to one month
+      await env.CHAT_HISTORY.put(sessionKey, JSON.stringify(session), { expirationTtl: 2592000 });
       return new Response(`<pre>${summary}</pre>`, { headers:{'Content-Type':'text/html;charset=UTF-8'} });
     }
 

--- a/workers/scheduler.js
+++ b/workers/scheduler.js
@@ -61,12 +61,14 @@ export default {
             );
             session.summary_email_sent = true;
             session.progress_status = 'summary-ready';
-            await env.CHAT_HISTORY.put(key.name, JSON.stringify(session), { expirationTtl: 86400 });
+            // Extend session retention to one month
+            await env.CHAT_HISTORY.put(key.name, JSON.stringify(session), { expirationTtl: 2592000 });
           }
           if (!session.nudge_sent && now - lastActive > 7200) {
             ctx.waitUntil(sendWhatsAppNudge(env, normalizePhoneNumber(key.name.slice(chatHistoryPrefix('whatsapp').length))));
             session.nudge_sent = true;
-            await env.CHAT_HISTORY.put(key.name, JSON.stringify(session), { expirationTtl: 86400 });
+            // Extend session retention to one month
+            await env.CHAT_HISTORY.put(key.name, JSON.stringify(session), { expirationTtl: 2592000 });
           }
         }
       }

--- a/workers/whatsapp-incoming.js
+++ b/workers/whatsapp-incoming.js
@@ -159,7 +159,8 @@ export async function handleWhatsAppRequest(request, env, ctx) {
     session.summary = summary;
     session.summary_email_sent = true;
     session.progress_status = "summary-ready";
-    await env.CHAT_HISTORY.put(sessionKey, JSON.stringify(session), { expirationTtl: 86400 });
+    // Extend session retention to one month
+    await env.CHAT_HISTORY.put(sessionKey, JSON.stringify(session), { expirationTtl: 2592000 });
     const twiml = `<?xml version="1.0" encoding="UTF-8"?><Response><Message>Done! 💌 I’ve sent your consultation summary to Tata by email.</Message></Response>`;
     return new Response(twiml, {
       headers: { "Content-Type": "text/xml; charset=UTF-8", "Access-Control-Allow-Origin": "*" },
@@ -218,8 +219,8 @@ export async function handleWhatsAppRequest(request, env, ctx) {
 
   session.history.push({ role: "assistant", content: assistantReply });
 
-  // Save session state with TTL
-  await env.CHAT_HISTORY.put(sessionKey, JSON.stringify(session), { expirationTtl: 86400 });
+  // Save session state with TTL of one month to retain conversations longer
+  await env.CHAT_HISTORY.put(sessionKey, JSON.stringify(session), { expirationTtl: 2592000 });
 
   console.log("Assistant reply", assistantReply);
 


### PR DESCRIPTION
## Summary
- retain session history in KV for one month instead of 24 hours
- update documentation to reflect new TTL

## Testing
- `npm test`