### PR TITLE
Clarify booking availability issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.9.6] - 2025-01-27
+
+- **Fixed Booking Availability**: Added missing BOOKSY_MCP_URL environment variable
+- **Corrected Worker URL**: Booksy dynamic worker now properly accessible at /booksy endpoints
+- **Production Fix**: Availability checks will now actually reach the booking system instead of failing silently
+
 ## [1.9.5] - 2025-07-06
 
 - **🎉 BREAKTHROUGH: Real Calendar Detection**: Successfully identified and implemented actual Booksy calendar selectors (.b-datepicker, .b-datepicker-days-row)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tataorowhatsappgpt",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Cloudflare Worker webhook handler for Twilio WhatsApp messages, powered by OpenAI's GPT-4o-mini (including Vision and Audio support).",
   "main": "index.js",
   "directories": {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,6 +29,7 @@ EMAIL_FROM = "consultations@tataoro.com"
 EMAIL_TO = "tatacurly@tataoro.com"
 SHOPIFY_STORE_DOMAIN = "tataoro.com"
 WHATSAPP_BASE_URL = "https://wa.tataoro.com"
+BOOKSY_MCP_URL = "https://wa.tataoro.com/booksy"
 
 [observability.logs]
 enabled = true


### PR DESCRIPTION
Fix booking availability by adding the missing `BOOKSY_MCP_URL` environment variable.

The booking system was failing because the `BOOKSY_MCP_URL` environment variable was not set, causing the application to attempt to reach a non-existent subdomain. The `booksy-dynamic` worker is actually deployed as part of the main application at `/booksy`. This PR configures the correct URL, allowing availability checks to reach the intended endpoint.